### PR TITLE
Expand license details in readme to include attribution requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 Rails 4.2 example application that provides GDS Admin layout, with basic
 admin functionality to enable fast prototyping of backend views
- 
+
 Includes :
- 
+
 The GovUK admin template :  https://github.com/alphagov/govuk_admin_template
 
 * "Devise" : https://github.com/plataformatec/devise (user management)
@@ -13,7 +13,7 @@ The GovUK admin template :  https://github.com/alphagov/govuk_admin_template
 
 
 Use this application to prototype static views (pages)
- 
+
 Drop .html.erb pages into app/views/pages
 
 ## Installation
@@ -21,7 +21,7 @@ Drop .html.erb pages into app/views/pages
 Fork or clone the project locally
 
 cd into the project and install dependencies as usual :
- 
+
 ```ruby
 bundle install
 ```
@@ -39,25 +39,25 @@ rake db:seed
 
 Run ```rake db:seed``` to populate Db with some sample Users.
 
-To change or add to the sample set, edit 
+To change or add to the sample set, edit
 ```
 db/seeds.rb
 ```
 
 To truncate and reseed the DB
- 
+
 ```
 rake db:reset
-``` 
+```
 
 ## Layout
 
-As well as static pages, you can use content_for hooks to inject content into 
+As well as static pages, you can use content_for hooks to inject content into
 in the GDS template. See the README for details of available content blocks
 here : https://github.com/alphagov/govuk_admin_template
- 
+
  e.g
- 
+
 ```ruby
 <% content_for ::navbar_right do %>
     <div>Some text for over there</div>
@@ -78,8 +78,16 @@ All contributions should be submitted via a pull request.
 
 ## License
 
-The Open Government Licence (OGL) is currently applied to this project. The OGL was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
+
+http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+>Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 
 It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.
-
-If you feel the OGL is blocking you from using this project please submit an issue telling us why and we'll do our best to help you.


### PR DESCRIPTION
Updated requirements from the Environment Agency Technical Design Authority require we explicitly tell people that they must include an attribution should they wish to use any part of the code.
