### PR TITLE
Update ref. factory_girl to factory_bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development do
 end
 
 group :test do
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,10 +62,10 @@ GEM
     erubi (1.7.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.8.1)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
@@ -192,7 +192,7 @@ DEPENDENCIES
   better_errors
   byebug
   coffee-rails (~> 4.1.0)
-  factory_girl_rails
+  factory_bot_rails
   faker
   govuk_admin_template (~> 4.1)
   high_voltage (~> 2.4.0)
@@ -208,9 +208,8 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
 
-
 RUBY VERSION
    ruby 2.2.3p173
 
 BUNDLED WITH
-   1.13.7
+   1.15.1

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     name "Test User"
     email "test@example.com"

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,3 @@
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
[ThoughtBot](https://thoughtbot.com/) the maintainers of the **factory_girl** gem recently decided to rename it to **factory_bot**. However as this was done on a fix version (0.0.x) its meant that a number of our projects see this as a potential update.

To get it to work though you not only need to change the reference in the Gemfile, but also how you reference it in the code. Hence any automated dependency checking services are suggesting the project takes the update but then CI is failing.

This change manually updates our reference to factory girl to use [factory_bot](https://github.com/thoughtbot/factory_bot) instead, and updates any references in the code to get the tests passing again.